### PR TITLE
client-api: Allow empty failures object in response to upload_signatu…

### DIFF
--- a/crates/ruma-client-api/src/keys/upload_signatures.rs
+++ b/crates/ruma-client-api/src/keys/upload_signatures.rs
@@ -45,7 +45,7 @@ pub mod v3 {
     #[derive(Default)]
     pub struct Response {
         /// Signature processing failures.
-        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        #[serde(default)]
         pub failures: BTreeMap<OwnedUserId, BTreeMap<String, Failure>>,
     }
 


### PR DESCRIPTION
…res.

<!--

PR checklist, not strictly necessary but generally useful unless you're just
fixing a typo or something like that:

- Run `cargo xtask ci` locally before posting the PR
- Documented public API changes in CHANGELOG.md files

-->
